### PR TITLE
Use error in response to propagate errors

### DIFF
--- a/lcservice-go/servers/iface.go
+++ b/lcservice-go/servers/iface.go
@@ -1,7 +1,9 @@
 package servers
 
+import svc "github.com/refractionPOINT/lc-service/lcservice-go/service"
+
 type Service interface {
 	Init() error
-	ProcessRequest(data map[string]interface{}, sig string) (response interface{}, isAccepted bool)
-	ProcessCommand(commandArguments map[string]interface{}, sig string) (response interface{}, isAccepted bool)
+	ProcessRequest(data map[string]interface{}, sig string) (response svc.Response, isAccepted bool)
+	ProcessCommand(commandArguments map[string]interface{}, sig string) (response svc.Response, isAccepted bool)
 }

--- a/lcservice-go/service/helpers.go
+++ b/lcservice-go/service/helpers.go
@@ -19,6 +19,8 @@ func NewErrorResponse(err error) Response {
 	return Response{Error: err.Error()}
 }
 
-func NewRetriableResponse(err string) Response {
-	return Response{IsRetriable: true, Data: Dict{"error": err}}
+func NewRetriableResponse(err error) Response {
+	resp := NewErrorResponse(err)
+	resp.IsRetriable = true
+	return resp
 }

--- a/lcservice-go/service/helpers.go
+++ b/lcservice-go/service/helpers.go
@@ -15,8 +15,8 @@ func DictToStruct(d Dict, s interface{}) error {
 	return nil
 }
 
-func NewErrorResponse(err string) Response {
-	return Response{Data: Dict{"error": err}}
+func NewErrorResponse(err error) Response {
+	return Response{Error: err.Error()}
 }
 
 func NewRetriableResponse(err string) Response {


### PR DESCRIPTION
- [x] Interface returns service.Response
- [x] Use the error response field for propagating errors - not data
- [x] Set http status of the response based on presence of error