### PR TITLE
Move interactive DR rule out of replicant namespace.

### DIFF
--- a/lcservice/service.py
+++ b/lcservice/service.py
@@ -700,7 +700,6 @@ class InteractiveService( Service ):
         self._rootInvestigationId = "svc-%s-ex" % ( self._serviceName, )
         self._interactiveRule = yaml.safe_load( f'''
             {self._rootInvestigationId}:
-              namespace: replicant
               detect:
                 op: and
                 rules:


### PR DESCRIPTION
## Description of the change

Moving the external services out of the `replicant` namespace to maintain integrity.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

