### PR TITLE
Move the auth tests to Server. Add Go test runs.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,4 +3,4 @@ steps:
     args: [ '-v', 'tests' ]
   - name: 'golang'
     dir: lcservice-go
-    args: ['go', 'test', '.', '-v']
+    args: ['go', 'test', './...', '-v']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,3 +1,6 @@
 steps:
   - name: 'gcr.io/${PROJECT_ID}/pytest_3'
     args: [ '-v', 'tests' ]
+  - name: 'golang'
+    dir: lcservice-go
+    args: ['go', 'test', '.', '-v']

--- a/lcservice-go/servers/common.go
+++ b/lcservice-go/servers/common.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 
@@ -70,12 +69,10 @@ func process(service Service, w http.ResponseWriter, r *http.Request) {
 }
 
 func verifyOrigin(data []byte, sig string, secretKey []byte) bool {
-	fmt.Printf("verify on\n%+v\n%s\n%s\n%s\n", data, string(data), sig, string(secretKey))
 	mac := hmac.New(sha256.New, secretKey)
 	if _, err := mac.Write(data); err != nil {
 		return false
 	}
 	jsonCompatSig := []byte(hex.EncodeToString(mac.Sum(nil)))
-	fmt.Println(string(jsonCompatSig))
 	return hmac.Equal(jsonCompatSig, []byte(sig))
 }

--- a/lcservice-go/servers/common_test.go
+++ b/lcservice-go/servers/common_test.go
@@ -2,6 +2,9 @@ package servers
 
 import (
 	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -17,6 +20,54 @@ import (
 const (
 	testSecretKey = "abc"
 )
+
+func TestAuth(t *testing.T) {
+	testMeCB := func(req svc.Request) svc.Response {
+		return svc.Response{IsSuccess: true}
+	}
+
+	a := assert.New(t)
+	s, err := svc.NewService(svc.Descriptor{
+		SecretKey:   testSecretKey,
+		Log:         func(m string) { fmt.Println(m) },
+		LogCritical: func(m string) { fmt.Printf("critial: %s\n", m) },
+		IsDebug:     true,
+		Commands: svc.CommandsDescriptor{
+			Descriptors: []svc.CommandDescriptor{
+				{
+					Name: "testMe",
+					Args: svc.CommandParams{
+						"arg0": svc.RequestParamDef{
+							Type:        svc.RequestParamTypes.String,
+							Description: "arg0 description",
+						},
+					},
+					Handler:     testMeCB,
+					Description: "test command",
+				},
+			},
+		},
+	})
+	a.NoError(err)
+
+	data := svc.Dict{
+		"etype": "health",
+		"data":  svc.Dict{},
+	}
+	dataBytes, err := json.Marshal(data)
+	a.NoError(err)
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest("", "http://test-url.com", bytes.NewReader(dataBytes))
+
+	// Set an invalid signature.
+	req.Header.Add("lc-svc-sig", "aaaabbbbcccc")
+
+	cf := NewCloudFunction(s)
+	cf.Process(recorder, req)
+
+	resp := recorder.Result()
+	a.Equal(http.StatusUnauthorized, resp.StatusCode)
+}
 
 func TestProcess(t *testing.T) {
 	testMeCB := func(req svc.Request) svc.Response {
@@ -35,10 +86,12 @@ func TestProcess(t *testing.T) {
 					Name: "testMe",
 					Args: svc.CommandParams{
 						"arg0": svc.RequestParamDef{
+							Type:        svc.RequestParamTypes.String,
 							Description: "arg0 description",
 						},
 					},
-					Handler: testMeCB,
+					Handler:     testMeCB,
+					Description: "test command",
 				},
 			},
 		},
@@ -53,7 +106,7 @@ func TestProcess(t *testing.T) {
 	a.NoError(err)
 	recorder := httptest.NewRecorder()
 	req := httptest.NewRequest("", "http://test-url.com", bytes.NewReader(dataBytes))
-	req.Header.Add("lc-svc-sig", "c8ef520e8d1047e137696e59d445b6cfd078b6c377d9af9dbf9ee37ccefdacb5")
+	req.Header.Add("lc-svc-sig", computeSig(dataBytes))
 
 	cf := NewCloudFunction(s)
 	cf.Process(recorder, req)
@@ -81,10 +134,23 @@ func TestProcess(t *testing.T) {
 	a.Equal(map[string]interface{}{
 		"testMe": svc.Dict{
 			"args": svc.Dict{
-				"arg0": "arg0 description",
+				"arg0": svc.Dict{
+					"desc":        "arg0 description",
+					"is_required": false,
+					"type":        "str",
+				},
 			},
 			"name": "testMe",
+			"desc": "test command",
 		},
 	}, respCommands)
+}
 
+func computeSig(data []byte) string {
+	mac := hmac.New(sha256.New, []byte(testSecretKey))
+	if _, err := mac.Write(data); err != nil {
+		return ""
+	}
+	jsonCompatSig := []byte(hex.EncodeToString(mac.Sum(nil)))
+	return string(jsonCompatSig)
 }

--- a/lcservice-go/servers/iface.go
+++ b/lcservice-go/servers/iface.go
@@ -4,6 +4,7 @@ import svc "github.com/refractionPOINT/lc-service/lcservice-go/service"
 
 type Service interface {
 	Init() error
-	ProcessRequest(data map[string]interface{}, sig string) (response svc.Response, isAccepted bool)
-	ProcessCommand(commandArguments map[string]interface{}, sig string) (response svc.Response, isAccepted bool)
+	ProcessRequest(data map[string]interface{}) svc.Response
+	ProcessCommand(commandArguments map[string]interface{}) svc.Response
+	GetSecretKey() []byte
 }

--- a/lcservice-go/service/interactive.go
+++ b/lcservice-go/service/interactive.go
@@ -119,12 +119,16 @@ func (is *InteractiveService) Init() error {
 	return is.cs.Init()
 }
 
-func (is *InteractiveService) ProcessRequest(data map[string]interface{}, sig string) (Response, bool) {
-	return is.cs.ProcessRequest(data, sig)
+func (is *InteractiveService) GetSecretKey() []byte {
+	return []byte(is.cs.desc.SecretKey)
 }
 
-func (is *InteractiveService) ProcessCommand(commandArguments map[string]interface{}, sig string) (Response, bool) {
-	return is.cs.ProcessCommand(commandArguments, sig)
+func (is *InteractiveService) ProcessRequest(data map[string]interface{}) Response {
+	return is.cs.ProcessRequest(data)
+}
+
+func (is *InteractiveService) ProcessCommand(commandArguments map[string]interface{}) Response {
+	return is.cs.ProcessCommand(commandArguments)
 }
 
 func (is *InteractiveService) getCbHash(cb interface{}) string {

--- a/lcservice-go/service/interactive_test.go
+++ b/lcservice-go/service/interactive_test.go
@@ -46,12 +46,7 @@ func TestInteractive(t *testing.T) {
 		Data:     Dict{},
 	})
 
-	sig := computeSig(testData)
-
-	resp, isAccepted := s.ProcessRequest(testData, sig)
-	if !isAccepted {
-		t.Error("valid sig not accepted")
-	}
+	resp := s.ProcessRequest(testData)
 	resp.Data["start_time"] = 0
 
 	if !compareResponses(resp, Response{
@@ -62,7 +57,7 @@ func TestInteractive(t *testing.T) {
 			"start_time":        0,
 			"mtd": Dict{
 				"request_params":       params,
-				"detect_subscriptions": []string{"d1", "d2", "svc-testService-ex"},
+				"detect_subscriptions": []string{"d1", "d2", "__svc-testService-ex"},
 				"callbacks":            []string{"detection", "health", "org_install", "org_per_1h", "org_uninstall"},
 				"commands":             Dict{},
 			},
@@ -98,12 +93,8 @@ func TestInteractive(t *testing.T) {
 			},
 		},
 	})
-	sig = computeSig(testData)
 
-	resp, isAccepted = s.ProcessRequest(testData, sig)
-	if !isAccepted {
-		t.Error("valid sig not accepted")
-	}
+	resp = s.ProcessRequest(testData)
 
 	if !compareResponses(resp, Response{
 		IsSuccess: true,


### PR DESCRIPTION
## Description of the change

Moving the auth check to the Server layer so we can more easily do the sig check on the body we receive instead of re-serializing it which was error prone.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

