### PR TITLE
Add concept of SessionID to propagate relevant JWTs.

### DIFF
--- a/lcservice-go/service/descriptor.go
+++ b/lcservice-go/service/descriptor.go
@@ -40,6 +40,18 @@ func (r Request) GetCommandID() (string, error) {
 	return cid, nil
 }
 
+func (r Request) GetSessionID() (string, error) {
+	eventSSID, found := r.Event.Data["ssid"]
+	if !found {
+		return "", fmt.Errorf("missing ssid (sessionID)")
+	}
+	ssid, ok := eventSSID.(string)
+	if !ok {
+		return "", fmt.Errorf("ssid is not a string")
+	}
+	return ssid, nil
+}
+
 type RequestEvent struct {
 	Type string
 	ID   string

--- a/lcservice-go/service/interactive.go
+++ b/lcservice-go/service/interactive.go
@@ -63,7 +63,8 @@ type InteractiveCallback = func(InteractiveRequest) Response
 // between Services and LimaCharlie.
 type interactiveContext struct {
 	CallbackID string `json:"cb"`
-	JobID      string `json:"j"`
+	JobID      string `json:"j,omitempty"`
+	SessionID  string `json:"s,omitempty"`
 	Context    Dict   `json:"c"`
 }
 
@@ -75,8 +76,9 @@ type inboundDetection struct {
 }
 
 type TrackedTaskingOptions struct {
-	Context Dict
-	JobID   string
+	Context   Dict
+	JobID     string
+	SessionID string
 }
 
 func NewInteractiveService(descriptor Descriptor, callbacks []InteractiveCallback) (is *InteractiveService, err error) {
@@ -261,6 +263,7 @@ func (is *InteractiveService) TrackedTasking(sensor *lc.Sensor, task string, opt
 	serialCtx, err := json.Marshal(interactiveContext{
 		CallbackID: cbHash,
 		JobID:      opts.JobID,
+		SessionID:  opts.SessionID,
 		Context:    opts.Context,
 	})
 	if err != nil {


### PR DESCRIPTION
## Description of the change

Track a SessionID from incoming Request to TrackedTasking in Interactive service. This is a value provided by LimaCharlie to correlate requests and actions to a single root interaction.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

