### PR TITLE
Hide the interactive rule by default.

### DIFF
--- a/lcservice-go/service/interactive.go
+++ b/lcservice-go/service/interactive.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	interactiveRuleTemplate = `
-%s:
+__%s:
   detect:
     op: and
     rules:


### PR DESCRIPTION
## Description of the change

Add a `__` prefix to hide the interactive rule by default so it doesn't pollute visually.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

