### PR TITLE
Expose Coreservice type so users can use logs.

### DIFF
--- a/lcservice-go/service/interactive.go
+++ b/lcservice-go/service/interactive.go
@@ -33,7 +33,7 @@ __%s:
 )
 
 type InteractiveService struct {
-	cs *coreService
+	cs *CoreService
 
 	// Rule used to get responses back.
 	detectionName   string


### PR DESCRIPTION
## Description of the change

Expose the CoreService type similarly to Interactive so that users can keep a reference to it and use it for Logging.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

