### PR TITLE
Do not set http error on user error

### DIFF
--- a/lcservice-go/servers/common.go
+++ b/lcservice-go/servers/common.go
@@ -19,12 +19,6 @@ func encodeResponse(resp svc.Response, w http.ResponseWriter) {
 }
 
 func handleResponse(resp svc.Response, w http.ResponseWriter) {
-	if resp.Error != "" {
-		w.WriteHeader(http.StatusBadRequest)
-		encodeResponse(resp, w)
-		return
-	}
-
 	w.WriteHeader(http.StatusOK)
 	encodeResponse(resp, w)
 }


### PR DESCRIPTION
## Description of the change

Do not set the http header as error on user error as we might retry on bad arguments/logic inside a service. Instead user should use the `IsRetriable` flag in the response to retry the request.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
