### PR TITLE
Add SID data type

### DIFF
--- a/lcservice-go/service/descriptor.go
+++ b/lcservice-go/service/descriptor.go
@@ -214,12 +214,14 @@ var RequestParamTypes = struct {
 	Int    RequestParamType
 	Bool   RequestParamType
 	UUID   RequestParamType
+	SID    RequestParamType
 }{
 	String: "str",
 	Enum:   "enum",
 	Int:    "int",
 	Bool:   "bool",
 	UUID:   "uuid",
+	SID:    "sid",
 }
 
 var SupportedRequestParamTypes = map[string]struct{}{
@@ -228,6 +230,7 @@ var SupportedRequestParamTypes = map[string]struct{}{
 	RequestParamTypes.Int:    {},
 	RequestParamTypes.Bool:   {},
 	RequestParamTypes.UUID:   {},
+	RequestParamTypes.SID:    {},
 }
 
 type Descriptor struct {


### PR DESCRIPTION
## Description of the change
Add `sid` as a data type so the web app can show appropriate controls for selecting a sensor.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
Closes https://github.com/refractionPOINT/tracking/issues/717
