### PR TITLE
Pass through command details into the command ack message

### DIFF
--- a/lcservice-go/service/core.go
+++ b/lcservice-go/service/core.go
@@ -155,10 +155,28 @@ func (r *commandHandlerResolver) preHandlerHook(request Request) error {
 		return nil
 	}
 
+	serviceName, err := request.GetString("service")
+	if err != nil {
+		return err
+	}
+
+	commandName, err := request.GetString("command_name")
+	if err != nil {
+		return err
+	}
+
+	commandRequest, err := request.Get("request")
+	if err != nil {
+		return err
+	}
+
 	if _, err := request.Org.Comms().Room(rid).Post(lc.NewMessage{
 		Type: lc.CommsMessageTypes.CommandAck,
 		Content: Dict{
-			"cid": cid,
+			"cid":           cid,
+			"commandName":   commandName,
+			"commandParams": commandRequest,
+			"serviceName":   serviceName,
 		},
 	}); err != nil {
 		return err


### PR DESCRIPTION
## Description of the change
Add command details into the `Post` call to the room when acking a command

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
Relates to https://github.com/refractionPOINT/tracking/issues/723
