### PR TITLE
Flatten message content of cmdack

### DIFF
--- a/lcservice-go/service/core.go
+++ b/lcservice-go/service/core.go
@@ -145,10 +145,6 @@ func (r *commandHandlerResolver) preHandlerHook(request Request) error {
 	if err != nil {
 		return err
 	}
-	cid, err := request.GetCommandID()
-	if err != nil {
-		return err
-	}
 
 	// Test compat, ignore if no SDK.
 	if request.Org == nil {
@@ -156,11 +152,8 @@ func (r *commandHandlerResolver) preHandlerHook(request Request) error {
 	}
 
 	if _, err := request.Org.Comms().Room(rid).Post(lc.NewMessage{
-		Type: lc.CommsMessageTypes.CommandAck,
-		Content: Dict{
-			"cid":     cid,
-			"command": request.Event.Data,
-		},
+		Type:    lc.CommsMessageTypes.CommandAck,
+		Content: request.Event.Data,
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description of the change
Previously was something like:
```json
{
  "cid": "2517dd08-c2c3-494b-9956-30a4f3fbb87d",
  "command": {
    "cid": "2517dd08-c2c3-494b-9956-30a4f3fbb87d",
    "command_name": "task",
    "rid": "2307597d-d7ca-4564-a11b-f158535b7dce",
    "sid": "d3d17f12-eecf-4176-b3a1-bf267ccbb3cf",
    "ssid": "badec230-ed0d-429e-83b9-af76dd17a41d",
    "task": "os_version"
  }
}
```

Flattening it to return the `command` key here as the entire message content.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
Relates to https://github.com/refractionPOINT/tracking/issues/723
