### PR TITLE
Add RequestRefs for exposing ack mid to services

### DIFF
--- a/lcservice-go/go.mod
+++ b/lcservice-go/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/uuid v1.2.0
-	github.com/refractionPOINT/go-limacharlie/limacharlie v0.0.0-20210519173405-d67becaf439d
+	github.com/refractionPOINT/go-limacharlie/limacharlie v0.0.0-20210629181236-a0a085a00064
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/lcservice-go/go.sum
+++ b/lcservice-go/go.sum
@@ -9,6 +9,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/refractionPOINT/go-limacharlie/limacharlie v0.0.0-20210519173405-d67becaf439d h1:IOVoGLLTwybmq+Aq3yNx6vWD3gRyGNMtRb92+dQSlaI=
 github.com/refractionPOINT/go-limacharlie/limacharlie v0.0.0-20210519173405-d67becaf439d/go.mod h1:EoshFrzawsMdzMWsZLCWNlsCYiHl4Du8D60/1i9wUR4=
+github.com/refractionPOINT/go-limacharlie/limacharlie v0.0.0-20210629181236-a0a085a00064 h1:C6lhv/oUG+PvoaIdViE0ASyiozwwAdVjD+TBHBODz1k=
+github.com/refractionPOINT/go-limacharlie/limacharlie v0.0.0-20210629181236-a0a085a00064/go.mod h1:5mF9lmWN1FdIcr6x9isB/09Ch76txHQF+KAOrgTJo8s=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.20.0 h1:38k9hgtUBdxFwE34yS8rTHmHBa4eN16E4DJlv177LNs=
 github.com/rs/zerolog v1.20.0/go.mod h1:IzD0RJ65iWH0w97OQQebJEvTZYvsCUm9WVLWBQrJRjo=

--- a/lcservice-go/service/descriptor.go
+++ b/lcservice-go/service/descriptor.go
@@ -12,6 +12,7 @@ import (
 
 // Input/Output from Service callbacks.
 type Request struct {
+	Refs     RequestRefs
 	Org      *lc.Organization
 	OID      string
 	Deadline time.Time
@@ -113,7 +114,16 @@ func (r Request) GetSessionID() (string, error) {
 	return r.GetString("ssid")
 }
 
+func (r Request) GetAckMessageID() string {
+	return r.Refs.AckMID
+}
+
+type RequestRefs struct {
+	AckMID string
+}
+
 type RequestEvent struct {
+	Refs RequestRefs
 	Type string
 	ID   string
 	Data Dict


### PR DESCRIPTION
## Description of the change
Draft attempt at exposing the `mid` that gets generated from `lc-service`'s `cmdack` so that services can reference it as a parent for future messages.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
Relates to https://github.com/refractionPOINT/tracking/issues/723
