### PR TITLE
Add commands once an interactive service is initialized

### DIFF
--- a/lcservice-go/service/command.go
+++ b/lcservice-go/service/command.go
@@ -1,7 +1,26 @@
 package service
 
+import (
+	"errors"
+	"fmt"
+)
+
 type CommandsDescriptor struct {
 	Descriptors []CommandDescriptor `json:"commands" msgpack:"commands"`
+}
+
+func (d CommandsDescriptor) isValid() error {
+	commandNames := map[string]struct{}{}
+	for _, command := range d.Descriptors {
+		if err := command.isValid(); err != nil {
+			return err
+		}
+		if _, ok := commandNames[command.Name]; ok {
+			return fmt.Errorf("command %s implemented more than once", command.Name)
+		}
+		commandNames[command.Name] = struct{}{}
+	}
+	return nil
 }
 
 type CommandName = string
@@ -11,4 +30,20 @@ type CommandDescriptor struct {
 	Description string          `json:"desc" msgpack:"desc"`
 	Args        CommandParams   `json:"args" msgpack:"args"`
 	Handler     ServiceCallback `json:"-" msgpack:"-"`
+}
+
+func (d CommandDescriptor) isValid() error {
+	if d.Name == "" {
+		return errors.New("command name cannot be empty")
+	}
+	if d.Description == "" {
+		return fmt.Errorf("command '%s' description is empty", d.Name)
+	}
+	if err := requestParamsIsValid(d.Args); err != nil {
+		return err
+	}
+	if d.Handler == nil {
+		return fmt.Errorf("command %s has a nil handler", d.Name)
+	}
+	return nil
 }

--- a/lcservice-go/service/descriptor.go
+++ b/lcservice-go/service/descriptor.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -307,24 +306,16 @@ type DescriptorCallbacks struct {
 }
 
 func (d Descriptor) IsValid() error {
-	commandNames := map[string]struct{}{}
-	for _, command := range d.Commands.Descriptors {
-		if command.Name == "" {
-			return errors.New("command name cannot be empty")
-		}
-		if command.Description == "" {
-			return fmt.Errorf("command '%s' description is empty", command.Name)
-		}
-		if err := requestParamsIsValid(command.Args); err != nil {
-			return err
-		}
-		if _, ok := commandNames[command.Name]; ok {
-			return fmt.Errorf("command %s implemented more than once", command.Name)
-		}
-		commandNames[command.Name] = struct{}{}
-		if command.Handler == nil {
-			return fmt.Errorf("command %s has a nil handler", command.Name)
-		}
+	return d.Commands.isValid()
+}
+
+func (d *Descriptor) addCommand(cmdDescriptor CommandDescriptor) error {
+	newCommandsDescriptor := CommandsDescriptor{
+		Descriptors: append(d.Commands.Descriptors, cmdDescriptor),
 	}
+	if err := newCommandsDescriptor.isValid(); err != nil {
+		return err
+	}
+	d.Commands = newCommandsDescriptor
 	return nil
 }

--- a/lcservice-go/service/interactive.go
+++ b/lcservice-go/service/interactive.go
@@ -111,11 +111,27 @@ func NewInteractiveService(descriptor Descriptor, callbacks []InteractiveCallbac
 
 	// Compute the callbacks.
 	is.interactiveCallbacks = map[string]InteractiveCallback{}
+	is.setInteractiveCallbacks(callbacks)
+
+	return is, err
+}
+
+func (is *InteractiveService) setInteractiveCallbacks(callbacks []InteractiveCallback) {
 	for _, cb := range callbacks {
 		is.interactiveCallbacks[is.getCbHash(cb)] = cb
 	}
+}
 
-	return is, err
+func (is *InteractiveService) RegisterCommand(cmdDescriptor CommandDescriptor, interactiveCb ...InteractiveCallback) error {
+	if err := is.cs.desc.addCommand(cmdDescriptor); err != nil {
+		return err
+	}
+	if len(interactiveCb) == 0 {
+		return nil
+	}
+
+	is.setInteractiveCallbacks([]InteractiveCallback{interactiveCb[0]})
+	return nil
 }
 
 func (is *InteractiveService) Init() error {

--- a/lcservice-go/service/interactive.go
+++ b/lcservice-go/service/interactive.go
@@ -68,7 +68,7 @@ func (r InteractiveRequest) GetFromContext(key string) (interface{}, error) {
 	return dataValue, nil
 }
 
-func (r InteractiveRequest) GetString(key string) (string, error) {
+func (r InteractiveRequest) GetStringFromContext(key string) (string, error) {
 	dataValue, err := r.GetFromContext(key)
 	if err != nil {
 		return "", err
@@ -80,7 +80,7 @@ func (r InteractiveRequest) GetString(key string) (string, error) {
 	return value, nil
 }
 
-func (r InteractiveRequest) GetEnumValue(key string, requestParams RequestParams) (string, error) {
+func (r InteractiveRequest) GetEnumValueFromContext(key string, requestParams RequestParams) (string, error) {
 	paramDef, found := requestParams[key]
 	if !found {
 		return "", fmt.Errorf("key '%s' is not an expected parameter", key)
@@ -88,7 +88,7 @@ func (r InteractiveRequest) GetEnumValue(key string, requestParams RequestParams
 	if paramDef.Type != RequestParamTypes.Enum {
 		return "", fmt.Errorf("key '%s' is not of enum type", key)
 	}
-	enumValue, err := r.GetString(key)
+	enumValue, err := r.GetStringFromContext(key)
 	if err != nil {
 		return "", err
 	}
@@ -101,7 +101,7 @@ func (r InteractiveRequest) GetEnumValue(key string, requestParams RequestParams
 	return "", fmt.Errorf("value '%s' is not a valid enum value for key '%s'", enumValue, key)
 }
 
-func (r InteractiveRequest) GetInt(key string) (int, error) {
+func (r InteractiveRequest) GetIntFromContext(key string) (int, error) {
 	dataValue, err := r.GetFromContext(key)
 	if err != nil {
 		return 0, err
@@ -113,7 +113,7 @@ func (r InteractiveRequest) GetInt(key string) (int, error) {
 	return value, nil
 }
 
-func (r InteractiveRequest) GetBool(key string) (bool, error) {
+func (r InteractiveRequest) GetBoolFromContext(key string) (bool, error) {
 	dataValue, err := r.GetFromContext(key)
 	if err != nil {
 		return false, err
@@ -131,8 +131,8 @@ func (r InteractiveRequest) GetBool(key string) (bool, error) {
 	return false, fmt.Errorf("key '%s' is not a boolean", key)
 }
 
-func (r InteractiveRequest) GetUUID(key string) (uuid.UUID, error) {
-	strValue, err := r.GetString(key)
+func (r InteractiveRequest) GetUUIDFromContext(key string) (uuid.UUID, error) {
+	strValue, err := r.GetStringFromContext(key)
 	if err != nil {
 		return uuid.UUID{}, err
 	}

--- a/lcservice-go/service/interactive.go
+++ b/lcservice-go/service/interactive.go
@@ -196,12 +196,12 @@ func NewInteractiveService(descriptor Descriptor, callbacks []InteractiveCallbac
 
 	// Compute the callbacks.
 	is.interactiveCallbacks = map[string]InteractiveCallback{}
-	is.setInteractiveCallbacks(callbacks)
+	is.registerInteractiveCallbacks(callbacks)
 
 	return is, err
 }
 
-func (is *InteractiveService) setInteractiveCallbacks(callbacks []InteractiveCallback) {
+func (is *InteractiveService) registerInteractiveCallbacks(callbacks []InteractiveCallback) {
 	for _, cb := range callbacks {
 		is.interactiveCallbacks[is.getCbHash(cb)] = cb
 	}
@@ -215,7 +215,7 @@ func (is *InteractiveService) RegisterCommand(cmdDescriptor CommandDescriptor, i
 		return nil
 	}
 
-	is.setInteractiveCallbacks([]InteractiveCallback{interactiveCb[0]})
+	is.registerInteractiveCallbacks([]InteractiveCallback{interactiveCb[0]})
 	return nil
 }
 


### PR DESCRIPTION
## Description of the change

1. Make it possible to add a command (and optionally a interactive callback) to an interactive service once it's already initialized. This gives more flexibility to the users.
2. Add accessors to InteractiveRequest context so that it's easier to interact with.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
