### PR TITLE
Adding SensorID and original Request to interactive Request.

### DIFF
--- a/lcservice-go/service/interactive.go
+++ b/lcservice-go/service/interactive.go
@@ -53,11 +53,13 @@ type InteractiveService struct {
 }
 
 type InteractiveRequest struct {
-	Org     *lc.Organization
-	OID     string
-	Event   Dict
-	Job     *Job
-	Context Dict
+	Org            *lc.Organization
+	OID            string
+	SID            string
+	Event          Dict
+	Job            *Job
+	Context        Dict
+	ServiceRequest Request
 }
 
 func (r InteractiveRequest) GetFromContext(key string) (interface{}, error) {
@@ -158,6 +160,7 @@ type inboundDetection struct {
 	Detect  Dict `json:"detect" msgpack:"detect"`
 	Routing struct {
 		InvestigationID string `json:"investigation_id" msgpack:"investigation_id"`
+		SensorID        string `json:"sid,omitempty" msgpack:"sid,omitempty"`
 	} `json:"routing" msgpack:"routing"`
 }
 
@@ -260,10 +263,12 @@ func (is *InteractiveService) onDetection(r Request) Response {
 		return is.originalOnDetection(r)
 	}
 	req := InteractiveRequest{
-		Org:     r.Org,
-		OID:     r.OID,
-		Event:   detection.Detect,
-		Context: ic.Context,
+		Org:            r.Org,
+		OID:            r.OID,
+		SID:            detection.Routing.SensorID,
+		Event:          detection.Detect,
+		Context:        ic.Context,
+		ServiceRequest: r,
 	}
 
 	if ic.JobID != "" {

--- a/lcservice-go/service/job.go
+++ b/lcservice-go/service/job.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -40,6 +41,17 @@ type hexDumpAttachment struct {
 type yamlAttachment struct {
 	caption string
 	data    string
+}
+
+type jsonAttachment struct {
+	caption string
+	data    string
+}
+
+type tableAttachment struct {
+	caption string
+	headers []string
+	rows    [][]string
 }
 
 func getMSTimestamp() int64 {
@@ -154,6 +166,44 @@ func (h yamlAttachment) ToJSON() map[string]interface{} {
 		"att_type": "yaml",
 		"caption":  h.caption,
 		"data":     h.data,
+	}
+}
+
+func NewJSONAttachment(caption string, data interface{}) JobAttachment {
+	y, err := json.Marshal(data)
+	if err != nil {
+		y = []byte(fmt.Sprintf("%+v", data))
+	}
+	h := jsonAttachment{
+		caption: caption,
+		data:    string(y),
+	}
+	return &h
+}
+
+func (h jsonAttachment) ToJSON() map[string]interface{} {
+	return map[string]interface{}{
+		"att_type": "yaml",
+		"caption":  h.caption,
+		"data":     h.data,
+	}
+}
+
+func NewTableAttachment(caption string, headers []string, rows [][]string) JobAttachment {
+	h := tableAttachment{
+		caption: caption,
+		headers: headers,
+		rows:    rows,
+	}
+	return &h
+}
+
+func (h tableAttachment) ToJSON() map[string]interface{} {
+	return map[string]interface{}{
+		"att_type": "table",
+		"caption":  h.caption,
+		"headers":  h.headers,
+		"rows":     h.rows,
 	}
 }
 

--- a/lcservice-go/service/job.go
+++ b/lcservice-go/service/job.go
@@ -2,9 +2,11 @@ package service
 
 import (
 	"encoding/base64"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+	"gopkg.in/yaml.v2"
 )
 
 type Job struct {
@@ -31,6 +33,11 @@ type JobAttachment interface {
 }
 
 type hexDumpAttachment struct {
+	caption string
+	data    string
+}
+
+type yamlAttachment struct {
 	caption string
 	data    string
 }
@@ -125,6 +132,26 @@ func NewHexDumpAttachment(caption string, data []byte) JobAttachment {
 func (h hexDumpAttachment) ToJSON() map[string]interface{} {
 	return map[string]interface{}{
 		"att_type": "hex_dump",
+		"caption":  h.caption,
+		"data":     h.data,
+	}
+}
+
+func NewYamlAttachment(caption string, data interface{}) JobAttachment {
+	y, err := yaml.Marshal(data)
+	if err != nil {
+		y = []byte(fmt.Sprintf("%+v", data))
+	}
+	h := yamlAttachment{
+		caption: caption,
+		data:    string(y),
+	}
+	return &h
+}
+
+func (h yamlAttachment) ToJSON() map[string]interface{} {
+	return map[string]interface{}{
+		"att_type": "yaml",
 		"caption":  h.caption,
 		"data":     h.data,
 	}


### PR DESCRIPTION
## Description of the change

Adding the SensorID and the original Service Request to the Interactive Request to make it easier for users to propagate the SID and SessionID across multiple callbacks.

Also adding a few missing Attachment types for Jobs.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

