### PR TITLE
Remove rule in right namespace.

### DIFF
--- a/lcservice-go/service/interactive.go
+++ b/lcservice-go/service/interactive.go
@@ -355,7 +355,7 @@ func (is *InteractiveService) applyInteractiveRule(org *lc.Organization) error {
 }
 
 func (is *InteractiveService) removeInteractiveRule(org *lc.Organization) error {
-	if err := org.DRRuleDelete(is.detectionName); err != nil {
+	if err := org.DRRuleDelete(is.detectionName, lc.WithNamespace("managed")); err != nil {
 		is.cs.desc.LogCritical(fmt.Sprintf("error removing interactive rule: %v", err))
 		return err
 	}


### PR DESCRIPTION
## Description of the change

The interactive rule was not being cleaned up because of the wrong namespace.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

