### PR TITLE
Handle json unmarshal of int to float64.

### DIFF
--- a/lcservice-go/service/descriptor.go
+++ b/lcservice-go/service/descriptor.go
@@ -66,7 +66,11 @@ func (r Request) GetInt(key string) (int, error) {
 	}
 	value, ok := dataValue.(int)
 	if !ok {
-		return 0, fmt.Errorf("key '%s' is not an integer", key)
+		f, ok := dataValue.(float64)
+		if !ok {
+			return 0, fmt.Errorf("key '%s' is not an integer", key)
+		}
+		value = int(f)
 	}
 	return value, nil
 }


### PR DESCRIPTION
## Description of the change

The default JSON unmarshaller uses float64 for integers.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


